### PR TITLE
Fix lightgbm-linux-arm

### DIFF
--- a/.github/workflows/lightgbm-linux-arm.yml
+++ b/.github/workflows/lightgbm-linux-arm.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ubuntu:16.04
+    container: ubuntu:20.04
     steps:
       - run: |
           apt update

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some projects include shared libraries as part of their releases:
 
 Library | Linux ARM | Mac ARM | Files | License
 --- | --- | --- | --- | ---
-[LightGBM](https://github.com/Microsoft/LightGBM) | | ✓ | [View](https://github.com/ankane/ml-builds/releases/tag/lightgbm-4.1.0) | MIT
+[LightGBM](https://github.com/Microsoft/LightGBM) | ✓ | ✓ | [View](https://github.com/ankane/ml-builds/releases/tag/lightgbm-4.6.0) | MIT
 
 ## Details
 


### PR DESCRIPTION
The workflow for lightgbm-linux-arm currently fails because node requires a newer glibc than the version that Ubuntu 16.04 provides[1]. I tried updating to Ubuntu 18.04[2], but actions/upload-artifact@v4 requires glibc >= 2.28, so I opted for Ubuntu 20.04 which provides glibc 2.31.

[1] https://github.com/joshheinrichs-shopify/ml-builds/actions/runs/15836677283/job/44641602869
[2] https://github.com/joshheinrichs-shopify/ml-builds/actions/runs/15837200139/job/44643098022